### PR TITLE
docs: fix code ticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Compose Charts
 
-<p>
 This is an exploratory playground library to figure out how to Draw and animate using Android Jetpack Compose library.
 Currently this is using `0.1.0-dev15` library.
-</p>
 
 ## How it looks:
 


### PR DESCRIPTION
The ` are not showing up as code snippet.