### PR TITLE
Update compose to 1.0.0-alpha11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Compose Charts
 
 This is an exploratory playground library to figure out how to Draw and animate using Android Jetpack Compose library.
-Currently this is using `1.0.0-alpha10` library.
+Currently this is using `1.0.0-alpha11` library.
 
 ## How it looks:
 

--- a/app/src/main/java/com/github/tehras/charts/theme/Theme.kt
+++ b/app/src/main/java/com/github/tehras/charts/theme/Theme.kt
@@ -30,7 +30,7 @@ private val DarkThemeColors = darkColors(
 @Composable
 fun ChartsTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    content: @Composable() () -> Unit
+    content: @Composable () -> Unit
 ) {
     MaterialTheme(
         colors = if (darkTheme) DarkThemeColors else LightThemeColors,

--- a/app/src/main/java/com/github/tehras/charts/ui/bar/BarChartScreen.kt
+++ b/app/src/main/java/com/github/tehras/charts/ui/bar/BarChartScreen.kt
@@ -1,15 +1,26 @@
 package com.github.tehras.charts.ui.bar
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.*
+import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.onCommit
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -31,7 +42,7 @@ fun BarChartScreen() {
             TopAppBar(
                 navigationIcon = {
                     IconButton(onClick = { ChartScreenStatus.navigateHome() }) {
-                        Icon(Icons.Filled.ArrowBack)
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Go back to home")
                     }
                 },
                 title = { Text(text = "Bar Chart") }
@@ -64,13 +75,8 @@ fun DrawValueLocation(
     barChartDataModel: BarChartDataModel,
     newLocation: (DrawLocation) -> Unit
 ) {
-    var selectedAlignment = barChartDataModel.labelLocation
-
-    // There might be a better way to do this, but `DrawValueLocation` wasn't updating because
-    // nothing here was a state. So wrapping `barChartDataModel` with `onCommit` will get a
-    // callback when `labelDrawer` is updated and force the view below to re-render.
-    onCommit(barChartDataModel.labelDrawer) {
-        selectedAlignment = barChartDataModel.labelLocation
+    val selectedAlignment = remember(barChartDataModel.labelDrawer) {
+        barChartDataModel.labelLocation
     }
 
     Row(
@@ -115,7 +121,7 @@ fun AddOrRemoveBar(barChartDataModel: BarChartDataModel) {
             enabled = barChartDataModel.bars.size > 2,
             onClick = { barChartDataModel.removeBar() },
             shape = CircleShape
-        ) { Icon(Icons.Filled.Remove) }
+        ) { Icon(Icons.Filled.Remove, contentDescription = "Remove bar from chart") }
         Row(
             modifier = Modifier.padding(horizontal = Margins.horizontal),
             verticalAlignment = CenterVertically
@@ -133,7 +139,7 @@ fun AddOrRemoveBar(barChartDataModel: BarChartDataModel) {
             enabled = barChartDataModel.bars.size < 6,
             onClick = { barChartDataModel.addBar() },
             shape = CircleShape
-        ) { Icon(Icons.Filled.Add) }
+        ) { Icon(Icons.Filled.Add, contentDescription = "Add bar to chart") }
     }
 }
 

--- a/app/src/main/java/com/github/tehras/charts/ui/line/LineChartScreen.kt
+++ b/app/src/main/java/com/github/tehras/charts/ui/line/LineChartScreen.kt
@@ -28,7 +28,7 @@ fun LineChartScreen() {
             TopAppBar(
                 navigationIcon = {
                     IconButton(onClick = { ChartScreenStatus.navigateHome() }) {
-                        Icon(Icons.Filled.ArrowBack)
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Go back to home")
                     }
                 },
                 title = { Text(text = "Line Chart") }

--- a/app/src/main/java/com/github/tehras/charts/ui/pie/PieChartScreen.kt
+++ b/app/src/main/java/com/github/tehras/charts/ui/pie/PieChartScreen.kt
@@ -1,6 +1,5 @@
 package com.github.tehras.charts.ui.pie
 
-import android.util.Log
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.*

--- a/app/src/main/java/com/github/tehras/charts/ui/pie/PieChartScreen.kt
+++ b/app/src/main/java/com/github/tehras/charts/ui/pie/PieChartScreen.kt
@@ -29,7 +29,7 @@ fun PieChartScreen() {
             TopAppBar(
                 navigationIcon = {
                     IconButton(onClick = { ChartScreenStatus.navigateHome() }) {
-                        Icon(Icons.Filled.ArrowBack)
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Go back to home")
                     }
                 },
                 title = { Text(text = "Pie Chart") }
@@ -110,7 +110,7 @@ private fun AddOrRemoveSliceRow(pieChartDataModel: PieChartDataModel) {
             onClick = { pieChartDataModel.removeSlice() },
             shape = CircleShape
         ) {
-            Icon(Icons.Filled.Remove)
+            Icon(Icons.Filled.Remove, contentDescription = "Remove slice from pie chart")
         }
         Row(
             modifier = Modifier.padding(horizontal = Margins.horizontal),
@@ -130,7 +130,7 @@ private fun AddOrRemoveSliceRow(pieChartDataModel: PieChartDataModel) {
             onClick = { pieChartDataModel.addSlice() },
             shape = CircleShape
         ) {
-            Icon(Icons.Filled.Add)
+            Icon(Icons.Filled.Add, contentDescription = "Add slice to pie chart")
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.0-beta03")
+        classpath("com.android.tools.build:gradle:7.0.0-alpha05")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
     }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,9 +1,9 @@
 @file:JvmName("Deps")
 
 object Versions {
-    const val composeCompilerVersion = "1.4.21"
+    const val composeCompilerVersion = "1.4.21-2"
     const val compose = "1.0.0-alpha11"
-    const val kotlin = "1.4.21"
+    const val kotlin = "1.4.21-2"
     const val targetSdk = 30
     const val buildVersion = "30.0.2"
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -2,7 +2,7 @@
 
 object Versions {
     const val composeCompilerVersion = "1.4.21"
-    const val compose = "1.0.0-alpha10"
+    const val compose = "1.0.0-alpha11"
     const val kotlin = "1.4.21"
     const val targetSdk = 30
     const val buildVersion = "30.0.2"

--- a/gradle/configure-compose.gradle
+++ b/gradle/configure-compose.gradle
@@ -14,7 +14,6 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerVersion Versions.composeCompilerVersion
         kotlinCompilerExtensionVersion Versions.compose
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Jun 13 09:37:52 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.8-rc-1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/bar/src/main/java/com/github/tehras/charts/bar/BarChart.kt
+++ b/lib/bar/src/main/java/com/github/tehras/charts/bar/BarChart.kt
@@ -5,6 +5,8 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.onCommit
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -20,24 +22,23 @@ import com.github.tehras.charts.bar.renderer.xaxis.SimpleXAxisDrawer
 import com.github.tehras.charts.bar.renderer.xaxis.XAxisDrawer
 import com.github.tehras.charts.bar.renderer.yaxis.SimpleYAxisDrawer
 import com.github.tehras.charts.bar.renderer.yaxis.YAxisDrawer
-import com.github.tehras.charts.piechart.animation.SimpleChartAnimation
+import com.github.tehras.charts.piechart.animation.simpleChartAnimation
 
 @Composable
 fun BarChart(
     barChartData: BarChartData,
     modifier: Modifier = Modifier,
-    animation: AnimationSpec<Float> = SimpleChartAnimation(),
+    animation: AnimationSpec<Float> = simpleChartAnimation(),
     barDrawer: BarDrawer = SimpleBarDrawer(),
     xAxisDrawer: XAxisDrawer = SimpleXAxisDrawer(),
     yAxisDrawer: YAxisDrawer = SimpleYAxisDrawer(),
     labelDrawer: LabelDrawer = SimpleValueDrawer()
 ) {
     val transitionProgress = animatedFloat(initVal = 0f)
-
-    onCommit(barChartData.bars, {
-        transitionProgress.snapTo(0f)
+    DisposableEffect(barChartData.bars) {
         transitionProgress.animateTo(1f, anim = animation)
-    })
+        onDispose { transitionProgress.snapTo(0f) }
+    }
 
     val progress = transitionProgress.value
 

--- a/lib/bar/src/main/java/com/github/tehras/charts/bar/BarChart.kt
+++ b/lib/bar/src/main/java/com/github/tehras/charts/bar/BarChart.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.onCommit
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas

--- a/lib/common/src/main/java/com/github/tehras/charts/piechart/animation/SimpleChartAnimation.kt
+++ b/lib/common/src/main/java/com/github/tehras/charts/piechart/animation/SimpleChartAnimation.kt
@@ -4,6 +4,6 @@ import androidx.compose.animation.core.TweenSpec
 import androidx.compose.runtime.Composable
 
 @Composable
-fun SimpleChartAnimation() = TweenSpec<Float>(
+fun simpleChartAnimation() = TweenSpec<Float>(
     durationMillis = 500
 )

--- a/lib/common/src/main/java/com/github/tehras/charts/piechart/animation/SimpleChartAnimation.kt
+++ b/lib/common/src/main/java/com/github/tehras/charts/piechart/animation/SimpleChartAnimation.kt
@@ -3,7 +3,4 @@ package com.github.tehras.charts.piechart.animation
 import androidx.compose.animation.core.TweenSpec
 import androidx.compose.runtime.Composable
 
-@Composable
-fun simpleChartAnimation() = TweenSpec<Float>(
-    durationMillis = 500
-)
+fun simpleChartAnimation() = TweenSpec<Float>(durationMillis = 500)

--- a/lib/line/src/main/java/com/github/tehras/charts/line/LineChart.kt
+++ b/lib/line/src/main/java/com/github/tehras/charts/line/LineChart.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.onCommit
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 

--- a/lib/line/src/main/java/com/github/tehras/charts/line/LineChart.kt
+++ b/lib/line/src/main/java/com/github/tehras/charts/line/LineChart.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.onCommit
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
@@ -25,13 +26,13 @@ import com.github.tehras.charts.line.renderer.xaxis.SimpleXAxisDrawer
 import com.github.tehras.charts.line.renderer.xaxis.XAxisDrawer
 import com.github.tehras.charts.line.renderer.yaxis.SimpleYAxisDrawer
 import com.github.tehras.charts.line.renderer.yaxis.YAxisDrawer
-import com.github.tehras.charts.piechart.animation.SimpleChartAnimation
+import com.github.tehras.charts.piechart.animation.simpleChartAnimation
 
 @Composable
 fun LineChart(
     lineChartData: LineChartData,
     modifier: Modifier = Modifier,
-    animation: AnimationSpec<Float> = SimpleChartAnimation(),
+    animation: AnimationSpec<Float> = simpleChartAnimation(),
     pointDrawer: PointDrawer = FilledCircularPointDrawer(),
     lineDrawer: LineDrawer = SolidLineDrawer(),
     xAxisDrawer: XAxisDrawer = SimpleXAxisDrawer(),
@@ -44,9 +45,9 @@ fun LineChart(
     }
 
     val transitionProgress = animatedFloat(initVal = 0f)
-    onCommit(lineChartData.points) {
-        transitionProgress.snapTo(0f)
-        transitionProgress.animateTo(1f, animation)
+    DisposableEffect(lineChartData.points) {
+        transitionProgress.animateTo(1f, anim = animation)
+        onDispose { transitionProgress.snapTo(0f) }
     }
 
     Canvas(modifier = modifier.fillMaxSize()) {

--- a/lib/pie/src/main/java/com/github/tehras/charts/piechart/PieChart.kt
+++ b/lib/pie/src/main/java/com/github/tehras/charts/piechart/PieChart.kt
@@ -5,13 +5,13 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.onCommit
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.tooling.preview.Preview
 import com.github.tehras.charts.piechart.PieChartUtils.calculateAngle
-import com.github.tehras.charts.piechart.animation.SimpleChartAnimation
+import com.github.tehras.charts.piechart.animation.simpleChartAnimation
 import com.github.tehras.charts.piechart.renderer.SimpleSliceDrawer
 import com.github.tehras.charts.piechart.renderer.SliceDrawer
 
@@ -20,16 +20,16 @@ import com.github.tehras.charts.piechart.renderer.SliceDrawer
 fun PieChart(
     pieChartData: PieChartData,
     modifier: Modifier = Modifier,
-    animation: AnimationSpec<Float> = SimpleChartAnimation(),
+    animation: AnimationSpec<Float> = simpleChartAnimation(),
     sliceDrawer: SliceDrawer = SimpleSliceDrawer()
 ) {
     val transitionProgress = animatedFloat(initVal = 0f)
 
     // When slices value changes we want to re-animated the chart.
-    onCommit(pieChartData.slices, {
-        transitionProgress.snapTo(0f)
+    DisposableEffect(pieChartData.slices) {
         transitionProgress.animateTo(1f, anim = animation)
-    })
+        onDispose { transitionProgress.snapTo(0f) }
+    }
 
     DrawChart(
         pieChartData = pieChartData,


### PR DESCRIPTION
I've also updated Koltin version to 1.4.21-2 as this is required for 1.0.0-alpha11. I've also replaced the occurrences of `onCommit`, which is now deprecated, with `DisposableEffect` where appropriate. The `Image` composeable also now requires a `contentDescription` so I've added a basic description for all of them.