### PR TITLE
App: Fix hardcoded colors

### DIFF
--- a/app/src/main/java/com/github/tehras/charts/ui/bar/BarChartScreen.kt
+++ b/app/src/main/java/com/github/tehras/charts/ui/bar/BarChartScreen.kt
@@ -1,20 +1,8 @@
 package com.github.tehras.charts.ui.bar
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Button
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
-import androidx.compose.material.TopAppBar
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
@@ -23,8 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -92,14 +78,8 @@ fun DrawValueLocation(
         .align(CenterVertically)
     ) {
       DrawLocation.values().forEach { location ->
-        val color = if (selectedAlignment == location) {
-          Color.Black
-        } else {
-          Color.Transparent
-        }
-
-        TextButton(
-          border = BorderStroke(2.dp, SolidColor(color)),
+        OutlinedButton(
+          border = ButtonDefaults.outlinedBorder.takeIf { selectedAlignment == location },
           onClick = { newLocation(location) }
         ) {
           Text(location.name)

--- a/app/src/main/java/com/github/tehras/charts/ui/line/LineChartScreen.kt
+++ b/app/src/main/java/com/github/tehras/charts/ui/line/LineChartScreen.kt
@@ -1,27 +1,12 @@
 package com.github.tehras.charts.ui.line
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Slider
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
-import androidx.compose.material.TopAppBar
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.tehras.charts.line.LineChart
@@ -84,14 +69,8 @@ fun HorizontalOffsetSelector(lineChartDataModel: LineChartDataModel) {
         .align(CenterVertically)
     ) {
       PointDrawerType.values().forEach { type ->
-        val color = if (selectedType == type) {
-          Color.Black
-        } else {
-          Color.Transparent
-        }
-
-        TextButton(
-          border = BorderStroke(2.dp, SolidColor(color)),
+        OutlinedButton(
+          border = ButtonDefaults.outlinedBorder.takeIf { selectedType == type },
           onClick = { lineChartDataModel.pointDrawerType = type }
         ) {
           Text(type.name)


### PR DESCRIPTION
Some buttons used hardcoded black borders. I've replaced them with `ButtonDefaults.outlinedBorder`, which uses `colors.onSurface`. The stroke is less thick and opaque but I think it's better this way because it adheres to material design.

This doesn't fix the hardcoded graph axis colors, which are declared in the library.

Before:
![Screenshot_20210406-222554_charts](https://user-images.githubusercontent.com/30440621/113774107-22e6c580-9727-11eb-9210-386df55b368b.png)


After: 
![image](https://user-images.githubusercontent.com/30440621/113576013-11b29180-961f-11eb-99aa-30983892954c.png)